### PR TITLE
Restart assistant session on web chat reload

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -224,9 +224,17 @@ export const handler = async (event) => {
       // Web/API genérico
       const parsed = rawBody ? JSON.parse(rawBody) : {};
       inputText = typeof parsed.input === "string" ? parsed.input : parsed.input?.text;
-      const baseId = parsed.userId || parsed?.requestContext?.identity?.sourceIp || parsed?.requestContext?.requestId || "anon";
+      
+      // Para web, generar siempre una nueva sesión a menos que se proporcione explícitamente un userId
+      // Esto asegura que cada recarga de página inicie una conversación fresca
+      const baseId = parsed.userId || 
+                     parsed?.requestContext?.requestId || 
+                     crypto.randomUUID() || 
+                     `anon-${Date.now()}`;
       userId = `web:${baseId}`;
-      history = await loadHistory(userId);
+      
+      // Solo cargar historial si se proporcionó un userId explícito (para mantener sesión existente)
+      history = parsed.userId ? await loadHistory(userId) : [];
     }
 
     // si no hay texto ni media -> registrar como mensaje vacío pero continuar conversación


### PR DESCRIPTION
Ensure web chat sessions start fresh on each page reload by generating unique session IDs by default.

Previously, web chat sessions persisted across page reloads because the user's IP address was used as the session identifier. This change ensures that each new page load initiates a fresh conversation, aligning with expected web chat behavior and user requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-80519cf3-cdcb-462d-81b0-eac41e5a9973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80519cf3-cdcb-462d-81b0-eac41e5a9973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

