### PR TITLE
Debug whatsapp adapter message sending

### DIFF
--- a/WhatsAppAdapter.mjs
+++ b/WhatsAppAdapter.mjs
@@ -62,17 +62,24 @@ export const handler = async (event) => {
 
     // Preparar mensaje para WhatsApp
     let mensaje = 'Sin respuesta IA';
-    if (Array.isArray(response.reply) && response.reply[0]?.text) {
-      mensaje = response.reply[0].text;
+    if (Array.isArray(response.reply) && response.reply.length > 0) {
+      // Concatenar todos los mensajes de texto de la respuesta
+      const mensajes = response.reply
+        .filter(item => item?.type === 'text' && item?.text)
+        .map(item => item.text);
+      
+      if (mensajes.length > 0) {
+        mensaje = mensajes.join('\n\n');
 
-      // Agregar respuesta al historial
-      history.push({
-        role: "assistant",
-        content: [{ type: "text", text: mensaje }]
-      });
+        // Agregar respuesta completa al historial
+        history.push({
+          role: "assistant",
+          content: response.reply
+        });
 
-      // Guardar historial actualizado
-      memory[userId] = history;
+        // Guardar historial actualizado
+        memory[userId] = history;
+      }
     }
 
     return {


### PR DESCRIPTION
Concatenate and send all text messages from AI responses to WhatsApp, fixing an issue where only the first message was being sent.

Previously, the adapter only extracted and sent `response.reply[0].text`, ignoring subsequent messages in the array. This change ensures all text parts are combined with `\n\n` and sent, and the full reply is stored in the conversation history.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bd6743c-14e6-41a1-a699-482fd5237e33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bd6743c-14e6-41a1-a699-482fd5237e33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

