### PR TITLE
Respond with assistant output

### DIFF
--- a/WhatsAppAdapter.mjs
+++ b/WhatsAppAdapter.mjs
@@ -511,7 +511,7 @@ export const handler = async (event) => {
     return {
       statusCode: 200,
       body: JSON.stringify({ 
-        status: "success",
+        response: replyText,
         messagesSent: messageParts.length
       })
     };


### PR DESCRIPTION
Return the assistant's `replyText` in the webhook response instead of a generic `status: "success"`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cf56e7d-0db4-4bac-aafa-977d85758045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cf56e7d-0db4-4bac-aafa-977d85758045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

