### PR TITLE
Show only Twilio response in WhatsAppAdapter

### DIFF
--- a/WhatsAppAdapter.mjs
+++ b/WhatsAppAdapter.mjs
@@ -510,9 +510,7 @@ export const handler = async (event) => {
     
     return {
       statusCode: 200,
-      body: JSON.stringify({ 
-        response: replyText
-      })
+      body: replyText
     };
     
   } catch (error) {


### PR DESCRIPTION
Remove `messagesSent` field from WhatsAppAdapter response body to only send the `response` field to Twilio.

---
<a href="https://cursor.com/background-agent?bcId=bc-270e62ed-d2f2-4be2-acd9-ee432ddc8d1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-270e62ed-d2f2-4be2-acd9-ee432ddc8d1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

